### PR TITLE
Fix yard error

### DIFF
--- a/funnel_http.gemspec
+++ b/funnel_http.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rake-compiler"
+  spec.add_development_dependency "redcarpet"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "steep"
   spec.add_development_dependency "yard"


### PR DESCRIPTION
```
[error]: Missing 'redcarpet' gem for Markdown formatting. Install it with `gem install redcarpet`
```