### PR TITLE
Tweak golangci-lint timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,6 +110,7 @@ jobs:
         with:
           version: v1.60
           working-directory: ext/funnel_http/
+          args: --timeout=5m
 
       - name: Slack Notification (not success)
         uses: act10ns/slack@v2


### PR DESCRIPTION
```
run golangci-lint
  Running [/home/runner/golangci-lint-1.60.3-linux-amd64/golangci-lint run --path-prefix=ext/funnel_http/] in [/home/runner/work/funnel_http/funnel_http/ext/funnel_http] ...
  Received 3342 of 3342 (100.0%), 0.0 MBs/sec
  level=error msg="Timeout exceeded: try increasing it by passing --timeout option"
```

https://github.com/sue445/funnel_http/actions/runs/11992670304/job/33432786093