### PR TITLE
Fix `Ruby::UnannotatedEmptyCollection` at `steep check`

### DIFF
--- a/lib/funnel_http/client.rb
+++ b/lib/funnel_http/client.rb
@@ -94,7 +94,10 @@ module FunnelHttp
           default_request_header.dup
         end
 
-      full_header.each_with_object({}) do |(k, v), hash|
+      # Workaround for Ruby::UnannotatedEmptyCollection on steep 1.9.0+
+      result = {} #: strict_header
+
+      full_header.each_with_object(result) do |(k, v), hash|
         # FIXME: Fails `steep check` when use Array(v)...
         # hash[k] = Array(v)
         hash[k] = v.is_a?(Array) ? v : Array(v)


### PR DESCRIPTION
```
Warning: l_http/client.rb:97:35: [warning] Empty hash doesn't have type annotation
│ Diagnostic ID: Ruby::UnannotatedEmptyCollection
│
└       full_header.each_with_object({}) do |(k, v), hash|
                                     ~~
```

Close #38