### PR TITLE
Fix CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,9 @@
 linters-settings:
-  gofmt:
   revive:
     rules:
       - name: exported
         arguments:
           - disableStutteringCheck
-  testifylint:
-  wrapcheck:
 
 linters:
   enable:


### PR DESCRIPTION
Close #60

```
Failed executing command with error: the configuration contains invalid elements
, Error: Command failed: /home/runner/golangci-lint-1.60.3-linux-amd64/golangci-lint config verify
jsonschema: "linters-settings.gofmt" does not validate with "/properties/linters-settings/properties/gofmt/type": expected object, but got null
jsonschema: "linters-settings.testifylint" does not validate with "/properties/linters-settings/properties/testifylint/type": expected object, but got null
jsonschema: "linters-settings.wrapcheck" does not validate with "/properties/linters-settings/properties/wrapcheck/type": expected object, but got null
Failed executing command with error: the configuration contains invalid elements
```