### PR TITLE
Add request url to response

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ requests = [
 
 responses = client.perform(requests)
 # => [
-#   { status_code: 200, body: "Response of /api/user/1", header: { "Content-Type" => ["text/plain;charset=utf-8"]} }
-#   { status_code: 200, body: "Response of /api/user/2", header: { "Content-Type" => ["text/plain;charset=utf-8"]} }
-#   { status_code: 200, body: "Response of /api/user", header: { "Content-Type" => ["text/plain;charset=utf-8"]} }
+#   { url: "https://example.com/api/user/1", status_code: 200, body: "Response of /api/user/1", header: { "Content-Type" => ["text/plain;charset=utf-8"]} }
+#   { url: "https://example.com/api/user/2", status_code: 200, body: "Response of /api/user/2", header: { "Content-Type" => ["text/plain;charset=utf-8"]} }
+#   { url: "https://example.com/api/user", status_code: 200, body: "Response of /api/user", header: { "Content-Type" => ["text/plain;charset=utf-8"]} }
 # ]
 ```
 

--- a/ext/funnel_http/funnel_http.go
+++ b/ext/funnel_http/funnel_http.go
@@ -44,6 +44,7 @@ func rb_funnel_http_run_requests(self C.VALUE, rbAry C.VALUE) C.VALUE {
 
 		ruby.RbHashAset(rbHash, ruby.RbId2Sym(ruby.RbIntern("status_code")), ruby.INT2NUM(response.StatusCode))
 		ruby.RbHashAset(rbHash, ruby.RbId2Sym(ruby.RbIntern("body")), ruby.String2Value(string(response.Body)))
+		ruby.RbHashAset(rbHash, ruby.RbId2Sym(ruby.RbIntern("url")), ruby.String2Value(string(response.URL)))
 
 		rbHashHeader := ruby.RbHashNew()
 		ruby.RbGcRegisterAddress(&rbHashHeader)

--- a/ext/funnel_http/run_requests.go
+++ b/ext/funnel_http/run_requests.go
@@ -18,6 +18,7 @@ type Request struct {
 
 // Response is proxy between CRuby and Go
 type Response struct {
+	URL        string
 	StatusCode int
 	Header     map[string][]string
 	Body       []byte
@@ -58,6 +59,7 @@ func RunRequests(httpClient *http.Client, requests []Request) ([]Response, error
 				return errors.WithStack(err)
 			}
 
+			responses[i].URL = request.URL
 			responses[i].Body = buf
 			responses[i].Header = map[string][]string{}
 

--- a/ext/funnel_http/run_requests_test.go
+++ b/ext/funnel_http/run_requests_test.go
@@ -82,6 +82,7 @@ func TestRunRequests(t *testing.T) {
 			},
 			expected: []main.Response{
 				{
+					URL:        "http://example.com/1",
 					StatusCode: 200,
 					Body:       []byte("GET http://example.com/1"),
 					Header: map[string][]string{
@@ -111,6 +112,7 @@ func TestRunRequests(t *testing.T) {
 			},
 			expected: []main.Response{
 				{
+					URL:        "http://example.com/1",
 					StatusCode: 200,
 					Body:       []byte("GET http://example.com/1"),
 					Header: map[string][]string{
@@ -119,6 +121,7 @@ func TestRunRequests(t *testing.T) {
 					},
 				},
 				{
+					URL:        "http://example.com/2",
 					StatusCode: 200,
 					Body:       []byte("GET http://example.com/2"),
 					Header: map[string][]string{
@@ -142,6 +145,7 @@ func TestRunRequests(t *testing.T) {
 			},
 			expected: []main.Response{
 				{
+					URL:        "http://example.com/1",
 					StatusCode: 200,
 					Body:       []byte("111"),
 					Header: map[string][]string{
@@ -173,6 +177,7 @@ func TestRunRequests(t *testing.T) {
 			},
 			expected: []main.Response{
 				{
+					URL:        "http://example.com/1",
 					StatusCode: 200,
 					Body:       []byte("111"),
 					Header: map[string][]string{
@@ -181,6 +186,7 @@ func TestRunRequests(t *testing.T) {
 					},
 				},
 				{
+					URL:        "http://example.com/1",
 					StatusCode: 200,
 					Body:       []byte("222"),
 					Header: map[string][]string{

--- a/lib/funnel_http/client.rb
+++ b/lib/funnel_http/client.rb
@@ -37,6 +37,7 @@ module FunnelHttp
     #   @option request :body [String, nil] Request body
     #
     # @return [Array<Hash<Symbol => Object>>] `Array` of following `Hash`
+    # @return [String] `:url` Request url
     # @return [Integer] `:status_code`
     # @return [String] `:body` Response body
     # @return [Hash{String => Array<String>}] `:header` Response header

--- a/sig/funnel_http.rbs
+++ b/sig/funnel_http.rbs
@@ -24,6 +24,7 @@ module FunnelHttp
   }
 
   type response = {
+    url: String,
     status_code: Integer,
     body: String,
     header: strict_header

--- a/spec/funnel_http/client_spec.rb
+++ b/spec/funnel_http/client_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe FunnelHttp::Client do
       describe "[0]" do
         subject { responses[0] }
 
+        its([:url]) { should eq "#{test_server}/get" }
         its([:status_code]) { should eq 200 }
         its([:body]) { should eq "/get" }
         its([:header]) { should include("Content-Type" => ["text/plain;charset=utf-8"]) }
@@ -39,6 +40,7 @@ RSpec.describe FunnelHttp::Client do
       describe "[1]" do
         subject { responses[1] }
 
+        its([:url]) { should eq "#{test_server}/get" }
         its([:status_code]) { should eq 200 }
         its([:body]) { should eq "/get" }
         its([:header]) { should include("Content-Type" => ["text/plain;charset=utf-8"]) }
@@ -63,6 +65,7 @@ RSpec.describe FunnelHttp::Client do
       describe "[0]" do
         subject { responses[0] }
 
+        its([:url]) { should eq "#{test_server}/get" }
         its([:status_code]) { should eq 200 }
         its([:body]) { should eq "/get" }
         its([:header]) { should include("Content-Type" => ["text/plain;charset=utf-8"]) }
@@ -87,6 +90,7 @@ RSpec.describe FunnelHttp::Client do
       describe "[0]" do
         subject { responses[0] }
 
+        its([:url]) { should eq "#{test_server}/get" }
         its([:status_code]) { should eq 200 }
         its([:body]) { should eq "/get" }
         its([:header]) { should include("Content-Type" => ["text/plain;charset=utf-8"]) }
@@ -124,6 +128,7 @@ RSpec.describe FunnelHttp::Client do
       describe "[0]" do
         subject { responses[0] }
 
+        its([:url]) { should eq "#{test_server}/post" }
         its([:status_code]) { should eq 200 }
         its([:body]) { should eq '{"value": "111"}' }
         its([:header]) { should include("Content-Type" => ["text/plain;charset=utf-8"]) }
@@ -134,6 +139,7 @@ RSpec.describe FunnelHttp::Client do
       describe "[1]" do
         subject { responses[1] }
 
+        its([:url]) { should eq "#{test_server}/post" }
         its([:status_code]) { should eq 200 }
         its([:body]) { should eq '{"value": "222"}' }
         its([:header]) { should include("Content-Type" => ["text/plain;charset=utf-8"]) }


### PR DESCRIPTION
To make it easier to identify which request caused the error when multiple requests are executed and an error occurs in some of them.

Strictly speaking, all `Request` should be included.

However, in many cases, the URL alone is sufficient, so in order not to increase the response size, only the URL is returned.