### PR TITLE
[CVE-2025-22874][CVE-2025-0913] Requires Go 1.24.4+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,11 +154,11 @@ jobs:
           ruby-version: ruby
           bundler-cache: true
 
-      - name: export CGO_CFLAGS for golangci-lint
+      - name: export CGO_CFLAGS for govulncheck
         run: bundle exec rake go:build_envs[CGO_CFLAGS] >> $GITHUB_ENV
       - run: echo $CGO_CFLAGS
 
-      - name: export BUILD_TAG for golangci-lint
+      - name: export BUILD_TAG for govulncheck
         run: echo "BUILD_TAG=$(bundle exec rake go:build_tag)" >> $GITHUB_ENV
       - run: echo $BUILD_TAG
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,10 +152,21 @@ jobs:
         run: bundle exec rake go:build_envs[CGO_CFLAGS] >> $GITHUB_ENV
       - run: echo $CGO_CFLAGS
 
-      - uses: golang/govulncheck-action@v1
+      - name: export BUILD_TAG for golangci-lint
+        run: echo "BUILD_TAG=$(bundle exec rake go:build_tag)" >> $GITHUB_ENV
+      - run: echo $BUILD_TAG
+
+      # FIXME: golang/govulncheck-action@v1 doesn't support `-tags` arg
+      # - uses: golang/govulncheck-action@v1
+      #   with:
+      #     go-version-file: ext/funnel_http/go.mod
+      #     work-dir: ext/funnel_http/
+      - uses: actions/setup-go@v6
         with:
           go-version-file: ext/funnel_http/go.mod
-          work-dir: ext/funnel_http/
+          cache: true
+      - run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - run: govulncheck -C ext/funnel_http/ -format text -tags "${BUILD_TAG}" ./...
 
       - name: Slack Notification (not success)
         uses: act10ns/slack@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,6 +141,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v5
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ruby
+          bundler-cache: true
+
+      - name: export CGO_CFLAGS for golangci-lint
+        run: bundle exec rake go:build_envs[CGO_CFLAGS] >> $GITHUB_ENV
+
       - uses: golang/govulncheck-action@v1
         with:
           go-version-file: ext/funnel_http/go.mod

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,6 +150,7 @@ jobs:
 
       - name: export CGO_CFLAGS for golangci-lint
         run: bundle exec rake go:build_envs[CGO_CFLAGS] >> $GITHUB_ENV
+      - run: echo $CGO_CFLAGS
 
       - uses: golang/govulncheck-action@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,11 +137,29 @@ jobs:
           status: ${{ job.status }}
           webhook-url: ${{ secrets.SLACK_WEBHOOK }}
 
+  govulncheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: golang/govulncheck-action@v1
+        with:
+          go-version-file: ext/funnel_http/go.mod
+          work-dir: ext/funnel_http/
+
+      - name: Slack Notification (not success)
+        uses: act10ns/slack@v2
+        if: "! success()"
+        continue-on-error: true
+        with:
+          status: ${{ job.status }}
+          webhook-url: ${{ secrets.SLACK_WEBHOOK }}
+
   notify:
     needs:
       - test
       - rbs
       - golangci-lint
+      - govulncheck
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,6 +143,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: ext/funnel_http/go.mod
+          cache: true
+      - run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ruby
@@ -161,11 +167,6 @@ jobs:
       #   with:
       #     go-version-file: ext/funnel_http/go.mod
       #     work-dir: ext/funnel_http/
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: ext/funnel_http/go.mod
-          cache: true
-      - run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - run: govulncheck -C ext/funnel_http/ -format text -tags "${BUILD_TAG}" ./...
 
       - name: Slack Notification (not success)

--- a/ext/funnel_http/go.mod
+++ b/ext/funnel_http/go.mod
@@ -1,6 +1,6 @@
 module github.com/sue445/funnel_http
 
-go 1.24.0
+go 1.24.4
 
 require (
 	github.com/cockroachdb/errors v1.12.0


### PR DESCRIPTION
c.f.
* https://pkg.go.dev/vuln/GO-2025-3749 (CVE-2025-22874)
* https://pkg.go.dev/vuln/GO-2025-3750 (CVE-2025-0913)

```
=== Symbol Results ===

Vulnerability https://github.com/sue445/funnel_http/pull/1: GO-2025-3750
    Inconsistent handling of O_CREATE|O_EXCL on Unix and Windows in os in
    syscall
  More info: https://pkg.go.dev/vuln/GO-2025-3750
  Standard library
    Found in: os@go1.24
    Fixed in: os@go1.24.4
    Platforms: windows
    Example traces found:
Error:       https://github.com/sue445/funnel_http/pull/1: run_requests.go:8:2: funnel_http.init calls http.init, which eventually calls os.NewFile
Error:       https://github.com/sue445/funnel_http/pull/2: run_requests.go:5:2: funnel_http.init calls errors.init, which eventually calls os.Open
Error:       https://github.com/sue445/funnel_http/pull/3: run_requests.go:8:2: funnel_http.init calls http.init, which eventually calls os.ReadDir
Error:       https://github.com/sue445/funnel_http/pull/4: run_requests.go:8:2: funnel_http.init calls http.init, which eventually calls os.ReadFile
Error:       https://github.com/sue445/funnel_http/pull/5: run_requests.go:5:2: funnel_http.init calls errors.init, which eventually calls os.Stat
Error:       https://github.com/sue445/funnel_http/pull/6: run_requests.go:8:2: funnel_http.init calls http.init, which eventually calls syscall.Open

Vulnerability https://github.com/sue445/funnel_http/pull/2: GO-2025-3749
    Usage of ExtKeyUsageAny disables policy validation in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2025-3749
  Standard library
    Found in: crypto/x509@go1.24
    Fixed in: crypto/x509@go1.24.4
    Example traces found:
Error:       https://github.com/sue445/funnel_http/pull/1: run_requests.go:8:2: funnel_http.init calls http.init, which eventually calls x509.Certificate.Verify

Your code is affected by 2 vulnerabilities from the Go standard library.
This scan also found 3 vulnerabilities in packages you import and 1
vulnerability in modules you require, but your code doesn't appear to call these
vulnerabilities.
Use '-show verbose' for more details.
Error: Process completed with exit code 3.
```